### PR TITLE
Workflow badges and official icon published in HA Brands

### DIFF
--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -26,5 +26,3 @@ jobs:
         uses: "hacs/action@main"
         with:
           category: "integration"
-          # In progress: Remove this 'ignore' key when you have added brand images for your integration to https://github.com/home-assistant/brands
-          ignore: "brands"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 [![hacs_badge](https://img.shields.io/badge/HACS-Custom-41BDF5.svg)](https://github.com/hacs/integration)
+![Validate workflow](https://github.com/joselcaguilar/azure-openai-ha/actions/workflows/validate.yaml/badge.svg)
+![Lint workflow](https://github.com/joselcaguilar/azure-openai-ha/actions/workflows/lint.yaml/badge.svg)
 ![GitHub all releases](https://img.shields.io/github/downloads/joselcaguilar/azure-openai-ha/total)
 [![GitHub Sponsor](https://img.shields.io/static/v1?label=Sponsor&message=%E2%9D%A4&logo=GitHub&color=%23fe8e86)](https://github.com/sponsors/joselcaguilar)
 [![BuyMeACoffee](https://img.shields.io/badge/-Buy_me_a%C2%A0coffee-gray?logo=buy-me-a-coffee)](https://www.buymeacoffee.com/joselcaguilar)


### PR DESCRIPTION
Changes:
- HACS and Lint workflows badges added to the README.md
- Icons have been merged in HA Brands (https://github.com/home-assistant/brands/pull/4291), removed the ignore validation from validate.yaml workflow