### PR TITLE
Fix breaking 2025.8 update

### DIFF
--- a/custom_components/azure_openai_conversation/conversation.py
+++ b/custom_components/azure_openai_conversation/conversation.py
@@ -257,9 +257,10 @@ class AzureOpenAIConversationEntity(
     async def async_added_to_hass(self) -> None:
         """When entity is added to Home Assistant."""
         await super().async_added_to_hass()
-        assist_pipeline.async_migrate_engine(
-            self.hass, "conversation", self.entry.entry_id, self.entity_id
-        )
+        # Breaking HA 2025.8
+        # assist_pipeline.async_migrate_engine(
+        #    self.hass, "conversation", self.entry.entry_id, self.entity_id
+        # )
         conversation.async_set_agent(self.hass, self.entry, self)
         self.entry.async_on_unload(
             self.entry.add_update_listener(self._async_entry_update_listener)


### PR DESCRIPTION
I ran into the same issue after updating to Home Assistant Core 2025.08.

The workaround that worked for me was to edit:

/config/custom_components/azure_openai_conversation/conversation.py
and comment out or remove the lines 260–262:

assist_pipeline.async_migrate_engine(
    self.hass, "conversation", self.entry.entry_id, self.entity_id
)
According to ChatGPT the function (async_migrate_engine) was removed in 2025.08, and its functionality is now handled internally by conversation.async_set_agent(), so there’s no replacement needed.