### PR TITLE
Potential Bug? Schema Validation - 2026.6.0

### DIFF
--- a/custom_components/azure_openai_conversation/conversation.py
+++ b/custom_components/azure_openai_conversation/conversation.py
@@ -84,10 +84,54 @@ def _format_tool(
     tool: llm.Tool, custom_serializer: Callable[[Any], Any] | None
 ) -> FunctionToolParam:
     """Format tool specification."""
+
+    def _to_azure_tool_schema(schema: Any) -> dict[str, Any]:
+        """Normalize schema to Azure/OpenAI function-tool requirements.
+
+        Azure rejects top-level oneOf/anyOf/allOf/enum/not and requires
+        an object at the top level.
+        """
+        if not isinstance(schema, dict):
+            return {"type": "object", "properties": {}}
+
+        normalized = dict(schema)
+
+        # HA tool schemas can be emitted as anyOf(object, null) for optional
+        # argument groups. Azure requires a top-level object.
+        for combiner in ("anyOf", "oneOf", "allOf"):
+            variants = normalized.get(combiner)
+            if isinstance(variants, list):
+                object_variant = next(
+                    (
+                        variant
+                        for variant in variants
+                        if isinstance(variant, dict)
+                        and (
+                            variant.get("type") == "object"
+                            or "properties" in variant
+                        )
+                    ),
+                    None,
+                )
+                if object_variant is not None:
+                    normalized = {**normalized, **object_variant}
+                normalized.pop(combiner, None)
+
+        normalized.pop("enum", None)
+        normalized.pop("not", None)
+
+        if normalized.get("type") != "object":
+            normalized["type"] = "object"
+
+        normalized.setdefault("properties", {})
+        return normalized
+
     return FunctionToolParam(
         type="function",
         name=tool.name,
-        parameters=convert(tool.parameters, custom_serializer=custom_serializer),
+        parameters=_to_azure_tool_schema(
+            convert(tool.parameters, custom_serializer=custom_serializer)
+        ),
         description=tool.description,
         strict=False,
     )

--- a/custom_components/azure_openai_conversation/conversation.py
+++ b/custom_components/azure_openai_conversation/conversation.py
@@ -1,6 +1,7 @@
 """Conversation support for OpenAI."""
 
 from collections.abc import AsyncGenerator, Callable
+from datetime import date, datetime, time
 import json
 from typing import Any, Literal, cast
 
@@ -68,6 +69,13 @@ from .const import (
 
 # Max number of back and forth with the LLM to generate a response
 MAX_TOOL_ITERATIONS = 10
+
+
+def _json_default(value: Any) -> str:
+    """Serialize values that appear in Home Assistant tool responses."""
+    if isinstance(value, (datetime, date, time)):
+        return value.isoformat()
+    return str(value)
 
 
 async def async_setup_entry(
@@ -147,7 +155,7 @@ def _convert_content_to_param(
             FunctionCallOutput(
                 type="function_call_output",
                 call_id=content.tool_call_id,
-                output=json.dumps(content.tool_result),
+                output=json.dumps(content.tool_result, default=_json_default),
             )
         ]
 


### PR DESCRIPTION
Not sure if this is related to 2026.6.0, but at some point recently I started to get failures every time I talked via voice to the Azure OpenAI Integration. The normal assistant via text was still working.

Error was:
```2026-05-07 20:08:44.777 ERROR (MainThread) [custom_components.azure_openai_conversation] Error talking to Azure OpenAI: Error code: 400 - {'error': {'message': "Invalid schema for function 'HassStartTimer': schema must have type 'object' and not have 'oneOf'/'anyOf'/'allOf'/'enum'/'not' at the top level.", 'type': 'invalid_request_error', 'param': 'tools[4].parameters', 'code': 'invalid_function_parameters'}}```

Ran it through Codex and it generated this fix, which seems to fix the problem for me. I'm wondering if others are seeing this issue or this is something on my side? Not too familiar with the schema validations