### PR TITLE
Fixing Support for 2026.9.0

### DIFF
--- a/custom_components/azure_openai_conversation/manifest.json
+++ b/custom_components/azure_openai_conversation/manifest.json
@@ -9,6 +9,6 @@
   "integration_type": "service",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/joselcaguilar/azure-openai-ha/issues",
-  "requirements": ["openai>=2.15.0,<3.0.0"],
-  "version": "2026.02.0"
+  "requirements": ["openai>=2.15.0,<3.0.0", "voluptuous-openapi>=0.4.1"],
+  "version": "2026.09.1"
 }

--- a/custom_components/azure_openai_conversation/requirements.txt
+++ b/custom_components/azure_openai_conversation/requirements.txt
@@ -1,1 +1,2 @@
 openai>=2.15.0,<3.0.0
+voluptuous-openapi>=0.4.1


### PR DESCRIPTION
Integration wasn't loading in 2026.9.0. Looks like there are new requirements needed in 2026.9.0. Added this to test and integration now loads in 2026.9.0